### PR TITLE
Add 2.5D approximation

### DIFF
--- a/EXAMPLES/2.5D_inplane/Par.inp
+++ b/EXAMPLES/2.5D_inplane/Par.inp
@@ -1,0 +1,31 @@
+#----- Some general parameters ----------------
+&GENERAL iexec=1, ngll=5, fmax=3.d0 , W=10d3, ndof=2 ,
+  title = '2.5D elastic in-plane model', verbose='1111' , ItInfo = 400/ 
+
+#----- Build the mesh ---------------------------
+&MESH_DEF  method = 'CARTESIAN'/
+&MESH_CART xlim=0d3,100d3, zlim=0d3,50d3, nelem=160,80/
+
+#---- Material parameters --------------
+&MATERIAL tag=1, kind='ELAST'  /
+&MAT_ELASTIC rho=2705.d0, cp=5770.d0, cs=3330.d0 /
+
+#----- Boundary conditions ---------------------
+&BC_DEF  tag = 1, kind = 'DYNFLT' /
+&BC_DYNFLT friction='SWF','TWF', Tn=-50d6,Tt=29d6 /
+&BC_DYNFLT_SWF Dc=0.4d0, MuS=0.63d0, MuD=0.54d0 /
+&BC_DYNFLT_TWF kind=1, MuS=0.63d0, MuD=0.54d0, Mu0=0.63d0, 
+               X=0.d0, Z=0.d0, V=0.333d3, L=0.1665d3, T=60d0 /
+
+&BC_DEF  tag = 2 , kind = 'ABSORB' /
+&BC_DEF  tag = 3 , kind = 'ABSORB' /
+&BC_DEF  tag = 4 , kind = 'DIRNEU' /
+&BC_DIRNEU h='N', v='D' /
+
+
+#---- Time scheme settings ----------------------
+&TIME  kind='leapfrog', TotalTime=60 /
+
+#--------- Plots settings ----------------------
+&SNAP_DEF itd=1000, fields ='DVS',bin=F,ps=T /
+&SNAP_PS  vectors=F, interpol=T, DisplayPts=6, ScaleField=0d0   /

--- a/SRC/input.f90
+++ b/SRC/input.f90
@@ -33,7 +33,7 @@ contains
   iin  = IO_new_unit()
   open (iin,file=input_file,status='old',action='read')
   
-  call read_gen(iexec,pb%fields%ndof,pb%grid%ngll,pb%grid%fmax,pb%grid%LY,iin)
+  call read_gen(iexec,pb%fields%ndof,pb%grid%ngll,pb%grid%fmax,pb%grid%W,iin)
 
  !---- mesh generation parameters     
   call MESH_read(pb%mesh,iin)
@@ -67,7 +67,7 @@ contains
 !
 ! NAME   : GENERAL
 ! PURPOSE: General parameters
-! SYNTAX : &GENERAL iexec, ngll, fmax, LY, title, verbose, itInfo /
+! SYNTAX : &GENERAL iexec, ngll, fmax, W, title, verbose, itInfo /
 !
 ! ARG: iexec    [int] [0] Run level:
 !                       0 = just check
@@ -79,7 +79,7 @@ contains
 !                This parameter is not used in computations, only for checking.
 !                To improve the resolution for a given fmax you must increase ngll 
 !                (but you will have to use shorter timesteps) or refine the mesh.
-! ARG: LY       [dble] [huge] The seismogenic width. Infinity means 2D problem and finite LY means 2.5D problem (use for elastic material)
+! ARG: W       [dble] [huge] The seismogenic width. Infinity means 2D problem and finite W means 2.5D problem (use for elastic material)
 ! ARG: ndof     [int] [2] Number of degrees of freedom per node
 !                       1 = SH waves, anti-plane
 !                       2 = P-SV waves, in-plane
@@ -96,25 +96,25 @@ contains
 !
 ! END INPUT BLOCK
 
-  subroutine read_gen(iexec,ndof,ngll,fmax,LY,iin)
+  subroutine read_gen(iexec,ndof,ngll,fmax,W,iin)
 
   use echo
   use stdio, only : IO_abort,abort_on_warnings
 
   integer, intent(in) :: iin
   integer  :: iexec,ndof,ngll
-  double precision :: fmax, LY
+  double precision :: fmax, W
   character(10) :: iexecname
   character(4) :: verbose
 
-  NAMELIST / GENERAL / iexec,ngll,ndof,fmax,LY,title,verbose,itInfo, &
+  NAMELIST / GENERAL / iexec,ngll,ndof,fmax,W,title,verbose,itInfo, &
                        abort_on_warnings
 
   iexec = 0
   ndof = 2
   ngll = 9
   fmax = 1d0
-  LY   = huge(1d0)
+  W    = huge(1d0)
   title   = ''
   verbose = '1101'
   itInfo  = 100
@@ -125,7 +125,7 @@ contains
   if (ndof>2 .or. ndof<1) call IO_abort('GENERAL input block: ndof must be 1 or 2 (SH or P-SV)')
   if (ngll <= 0) call IO_abort('GENERAL input block: ngll must be positive')
   if (fmax <= 0.d0) call IO_abort('GENERAL input block: fmax must be positive')
-  if (LY   <= 0.d0) call IO_abort('GENERAL input block: LY must be positive')
+  if (W    <= 0.d0) call IO_abort('GENERAL input block: W must be positive')
   if (itInfo<=0) call IO_abort('GENERAL input block: itInfo must be positive')
 
   if (iexec==0) then
@@ -142,7 +142,7 @@ contains
     write(iout,'(a)') '*            I n p u t   p h a s e            *'
     write(iout,'(a)') '***********************************************'
     write(iout,*)
-    write(iout,200) iexecname,ngll,ndof,fmax,LY, &
+    write(iout,200) iexecname,ngll,ndof,fmax,W, &
       echo_input,echo_init,echo_check,echo_run,itInfo,abort_on_warnings
   endif
 
@@ -155,7 +155,7 @@ contains
   'Number of nodes per edge . . . . . . . . . . .(ngll) = ',I0/5x, &
   'Number of d.o.f per node . . . . . . . . . . .(ndof) = ',I0/5x, &
   'Highest frequency to be resolved . . . . . . .(fmax) = ',EN12.3/5x, &
-  'Seismogenic width for 2.5D problem (elastic) . .(LY) = ',EN12.3/5x, &
+  'Seismogenic width for 2.5D problem (elastic) . .(W) = ',EN12.3/5x, &
   'Print progress information during ',/5x, &
   '            input phase  . . . . . . . .(verbose(1)) = ',L1/ 5x, &
   '            initialization phase . . . .(verbose(2)) = ',L1/ 5x, &

--- a/SRC/mat_elastic.f90
+++ b/SRC/mat_elastic.f90
@@ -29,7 +29,7 @@ module mat_elastic
           , MAT_ELAST_init_elem_prop, MAT_ELAST_init_elem_work &
           , MAT_ELAST_f, MAT_ELAST_stress &
           , MAT_ELAST_memwrk, MAT_ELAST_mempro &
-          , MAT_CP_add_f
+          , MAT_ELAST_add_25D_f
 
 
 contains
@@ -277,10 +277,10 @@ contains
                    + size( transfer(matwrk, (/ 0d0 /) )) &
                    + size(matwrk%a)
 
-  if (grid%LY < huge(1d0)) then
+  if (grid%W < huge(1d0)) then
      allocate(matwrk%beta(grid%ngll,grid%ngll))
-     call MAT_ELAST_init_CrustalPlane(matwrk%beta,grid%ngll &
-                   , SE_VolumeWeights(grid,e),grid%LY,matpro,ndof)
+     call MAT_ELAST_init_25D(matwrk%beta,grid%ngll &
+                   , SE_VolumeWeights(grid,e),grid%W,matpro,ndof)
   endif
 
 
@@ -360,29 +360,29 @@ contains
   end subroutine MAT_ELAST_init_a
 
 !==============================================
-  subroutine MAT_ELAST_init_CrustalPlane(beta,ngll,dvol,LY,mat,ndof)
+  subroutine MAT_ELAST_init_25D(beta,ngll,dvol,W,mat,ndof)
 
   integer, intent(in) :: ngll,ndof
   double precision, intent(out) :: beta(ngll,ngll)
   double precision, dimension(ngll,ngll), intent(in) :: dvol
-  double precision, intent(in) :: LY
+  double precision, intent(in) :: W
   type(matpro_elem_type), intent(in) :: mat
 
   double precision, dimension(ngll,ngll) :: mu
 
   call MAT_getProp(mu,mat,'mu') 
   if(ndof == 1) then
-      beta(:,:) = dvol(:,:) * mu(:,:) * (4.D0*DATAN(1.D0) / 2 / LY)**2
+      beta(:,:) = dvol(:,:) * mu(:,:) * (4.D0*DATAN(1.D0) / 2 / W)**2
   else
   ! Change this coefficient later
-      beta(:,:) = dvol(:,:) * mu(:,:) * (4.D0*DATAN(1.D0) / 2 / LY)**2
+      beta(:,:) = dvol(:,:) * mu(:,:) * (4.D0*DATAN(1.D0) / 2 / W)**2
   endif
 
-  end subroutine MAT_ELAST_init_CrustalPlane
+  end subroutine MAT_ELAST_init_25D
 
 !=======================================================================
 !
-! Computes the elastic internal forces term = -K*displ - displ/(beta*LY) 
+! Computes the elastic internal forces term = -K*displ - displ/(beta*W) 
 ! in a SEM grid using the coefficients in elast.
 ! On output the result is stored in the field KD (scratched)
 !
@@ -424,7 +424,7 @@ contains
 !=======================================================================
 ! Compute the forces acted on "crustal plane" approximated by Lapusta and Rice
 !
-subroutine MAT_CP_add_f(f,d,elast,ngll,ndof)
+subroutine MAT_ELAST_add_25D_f(f,d,elast,ngll,ndof)
   integer, intent(in) :: ngll,ndof
   double precision, intent(out):: f(ngll,ngll,ndof)
   double precision, intent(in) :: d(ngll,ngll,ndof)
@@ -436,7 +436,7 @@ subroutine MAT_CP_add_f(f,d,elast,ngll,ndof)
        f(:,:,k) = f(:,:,k) - elast%beta(:,:) * d(:,:,k)
     enddo
 
-end subroutine MAT_CP_add_f
+end subroutine MAT_ELAST_add_25D_f
 
 
 !----------------------------------------------------------------

--- a/SRC/mat_gen.f90
+++ b/SRC/mat_gen.f90
@@ -438,7 +438,7 @@ subroutine MAT_Fint(f,d,v,matpro,matwrk,ngll,ndof,dt,grid, E_ep,E_el,sg,sgp)
    ! elastic material has a specialized scheme
    ! that does not require intermediate computation of strain and stress
     call MAT_ELAST_f(f,d,matwrk%elast,grid%hprime,grid%hTprime,ngll,ndof)
-    if (grid%LY < huge(1d0)) call MAT_CP_add_f(f,d,matwrk%elast,ngll,ndof)
+    if (grid%W < huge(1d0)) call MAT_CP_add_f(f,d,matwrk%elast,ngll,ndof)
 
     E_ep = 0d0
     E_el = 0d0

--- a/SRC/mat_gen.f90
+++ b/SRC/mat_gen.f90
@@ -437,8 +437,9 @@ subroutine MAT_Fint(f,d,v,matpro,matwrk,ngll,ndof,dt,grid, E_ep,E_el,sg,sgp)
   if (MAT_isElastic(matpro)) then
    ! elastic material has a specialized scheme
    ! that does not require intermediate computation of strain and stress
-    call MAT_ELAST_f(f,d,matwrk%elast,grid%hprime,grid%hTprime,ngll,ndof) 
-  !if (MAT_isCrustalPlane(matpro)) call MAT_CP_add_f(d,matwrk%cp,ngll,ndof) !DEVEL
+    call MAT_ELAST_f(f,d,matwrk%elast,grid%hprime,grid%hTprime,ngll,ndof)
+    if (grid%LY < huge(1d0)) call MAT_CP_add_f(f,d,matwrk%elast,ngll,ndof)
+
     E_ep = 0d0
     E_el = 0d0
     sg = 0d0

--- a/SRC/spec_grid.f90
+++ b/SRC/spec_grid.f90
@@ -32,8 +32,8 @@ module spec_grid
 !------ Other
 !     tag          = element -> domain tags
 !     fmax         = Highest frequency to be resolved by the grid
-!     LY           = The seismogenic width. Infinity means 2D problem 
-!                    and finite LY means 2.5D problem (use for elastic material)
+!     W            = The seismogenic width. Infinity means 2D problem 
+!                    and finite W means 2.5D problem (use for elastic material)
 
 !
 !
@@ -49,7 +49,7 @@ module spec_grid
   type sem_grid_type
     integer :: ngll=0,nelem=0,npoin=0
     type(fem_grid_type) :: fem
-    double precision :: fmax=0d0, LY = huge(1d0)
+    double precision :: fmax=0d0, W = huge(1d0)
     double precision, pointer :: coord(:,:)      =>null(), &
                                  hprime(:,:)     =>null(), &
                                  hTprime(:,:)    =>null(), &

--- a/SRC/spec_grid.f90
+++ b/SRC/spec_grid.f90
@@ -32,6 +32,9 @@ module spec_grid
 !------ Other
 !     tag          = element -> domain tags
 !     fmax         = Highest frequency to be resolved by the grid
+!     LY           = The seismogenic width. Infinity means 2D problem 
+!                    and finite LY means 2.5D problem (use for elastic material)
+
 !
 !
 ! NOTE: After initialization, the FEM mesh database is only used for plotting
@@ -46,7 +49,7 @@ module spec_grid
   type sem_grid_type
     integer :: ngll=0,nelem=0,npoin=0
     type(fem_grid_type) :: fem
-    double precision :: fmax=0d0
+    double precision :: fmax=0d0, LY = huge(1d0)
     double precision, pointer :: coord(:,:)      =>null(), &
                                  hprime(:,:)     =>null(), &
                                  hTprime(:,:)    =>null(), &


### PR DESCRIPTION
Define seismogenic width LY in type sem_grid_type and read it from block $GENERAL 
Define beta in type matwrk_elast_type to save dvol*mu*(pi/LY)**2, initiated by subroutine MAT_ELAST_init_CrustalPlane(beta,ngll,dvol,LY,mat,ndof)
Use function MAT_CP_add_f to add the effects of seismogenic boundaries by: if (grid%LY < huge(1d0)) call MAT_CP_add_f(f,d,matwrk%elast,ngll,ndof)