### PR TITLE
2.5D option for plastic material implemented

### DIFF
--- a/SRC/bc_dynflt_rsf.f90
+++ b/SRC/bc_dynflt_rsf.f90
@@ -334,7 +334,7 @@ contains
   type(rsf_type), intent(in) :: f
   double precision, dimension(size(tau_stick)) :: v
   double precision :: tmp(size(tau_stick)), tolerance, estimateLow, estimateHigh
-  integer :: i
+  integer :: i, it
 
 !  strength = -sigma*rsf_mu_no_direct(v,f) 
 !  v = (tau_stick-strength)/Z

--- a/SRC/mat_gen.f90
+++ b/SRC/mat_gen.f90
@@ -369,8 +369,7 @@ subroutine MAT_init_work(matwrk,matpro,grid,ndof,dt)
       allocate(matwrk(e)%derint)
       allocate(matwrk(e)%plast)
       call MAT_set_derint(matwrk(e)%derint,grid,e)
-      call MAT_PLAST_init_elem_work(matwrk(e)%plast,matpro(e),grid%ngll,dt)
-      !call MAT_PLAST_init_elem_work(matwrk(e)%plast,matpro(e),grid%ngll,dt, SE_elem_coord(grid,e))
+      call MAT_PLAST_init_elem_work(matwrk(e)%plast,matpro(e),grid%ngll,dt,grid,e,ndof)
 
     elseif (MAT_isDamage(matpro(e))) then
       allocate(matwrk(e)%derint)
@@ -444,6 +443,12 @@ subroutine MAT_Fint(f,d,v,matpro,matwrk,ngll,ndof,dt,grid, E_ep,E_el,sg,sgp)
     E_el = 0d0
     sg = 0d0
     sgp = 0d0
+  elseif (MAT_isPlastic(matpro)) then
+    e  = MAT_strain(d,matwrk,ngll,ndof)
+    call MAT_stress(s,e,matwrk,matpro,ngll,ndof,.true.,dt,E_ep,E_el,sg,sgp)
+    f = MAT_forces(s,matwrk%derint,ngll,ndof)
+    if (grid%W < huge(1d0)) call MAT_PLAST_add_25D_f(f,d,matwrk%plast,ngll,ndof)
+
   else
     e  = MAT_strain(d,matwrk,ngll,ndof)
 ! DEVEL: the Kelvin-Voigt term should involve only the elastic strain rate (total - plastic)

--- a/SRC/mat_plastic.f90
+++ b/SRC/mat_plastic.f90
@@ -1,5 +1,5 @@
 module mat_plastic
-! plane strain Coulomb plasticity following Andrews (2005)
+! plane strain Coulomb plasticity following Andrews (2005) with added W term option
 
   use prop_mat
   use stdio, only : IO_abort
@@ -10,6 +10,7 @@ module mat_plastic
  !-- elasto-visco-plasticity
   type matwrk_plast_type
     private
+    double precision, pointer :: a(:,:,:) => null(), beta(:,:) => null()
 !    double precision, pointer, dimension(:,:) :: mu => null(), lambda => null()
     double precision :: mu, lambda
     double precision, pointer, dimension(:,:,:) :: ep => null()
@@ -26,7 +27,8 @@ module mat_plastic
   public :: matwrk_plast_type &
           , MAT_isPlastic, MAT_anyPlastic, MAT_PLAST_read, MAT_PLAST_init_elem_prop &
           , MAT_PLAST_init_elem_work, MAT_PLAST_stress, MAT_PLAST_export &
-          , MAT_PLAST_mempro, MAT_PLAST_memwrk
+          , MAT_PLAST_mempro, MAT_PLAST_memwrk &
+          , MAT_PLAST_add_25D_f
   
 contains
 
@@ -143,14 +145,17 @@ contains
   end subroutine MAT_PLAST_init_elem_prop
 
 !=======================================================================
-  subroutine MAT_PLAST_init_elem_work(m,p,ngll,dt)
+  subroutine MAT_PLAST_init_elem_work(m,p,ngll,dt,grid,e,ndof)
 
   use constants, only : PI
-
+  use spec_grid, only : sem_grid_type, SE_InverseJacobian, SE_VolumeWeights
+  
+  type(sem_grid_type), intent(in) :: grid
   type(matwrk_plast_type), intent(inout) :: m
   type(matpro_elem_type), intent(in) :: p
   integer, intent(in) :: ngll
   double precision, intent(in) :: dt
+  integer, intent(in) :: e,ndof
 
   double precision :: phi,Tv,lambda,two_mu
 
@@ -204,7 +209,53 @@ contains
 !                   + size(m%lambda) &
 !                   + size(m%mu) &
 
+  if (grid%W < huge(1d0)) then
+     allocate(m%beta(grid%ngll,grid%ngll))
+     call MAT_PLAST_init_25D(m%beta,grid%ngll &
+                   , SE_VolumeWeights(grid,e),grid%W,p,ndof)
+  endif
+
   end subroutine MAT_PLAST_init_elem_work
+
+!==============================================
+  subroutine MAT_PLAST_init_25D(beta,ngll,dvol,W,mat,ndof)
+
+  integer, intent(in) :: ngll,ndof
+  double precision, intent(out) :: beta(ngll,ngll)
+  double precision, dimension(ngll,ngll), intent(in) :: dvol
+  double precision, intent(in) :: W
+  type(matpro_elem_type), intent(in) :: mat
+
+  double precision, dimension(ngll,ngll) :: mu, lambda, nu
+
+  call MAT_getProp(mu,mat,'mu')
+  call MAT_getProp(lambda,mat,'lambda')
+
+  nu(:,:) = lambda(:,:) / (lambda(:,:) + mu(:,:)) / 2.0
+  if(ndof == 1) then
+      beta(:,:) = dvol(:,:) * mu(:,:) * (4.D0*DATAN(1.D0)/W)**2
+  else
+      beta(:,:) = dvol(:,:) * mu(:,:) * (4.D0*DATAN(1.D0)*(1-nu(:,:))/W)**2
+  endif
+
+end subroutine MAT_PLAST_init_25D
+
+!=======================================================================
+! Compute the forces acted on "crustal plane" approximated by Lapusta and Rice
+!
+subroutine MAT_PLAST_add_25D_f(f,d,plast,ngll,ndof)
+  integer, intent(in) :: ngll,ndof
+  double precision, intent(out):: f(ngll,ngll,ndof)
+  double precision, intent(in) :: d(ngll,ngll,ndof)
+  type (matwrk_plast_type), intent(in) :: plast
+
+  integer :: k
+
+    do k=1,ndof
+       f(:,:,k) = f(:,:,k) - plast%beta(:,:) * d(:,:,k)
+    enddo
+
+end subroutine MAT_PLAST_add_25D_f
 
 
 !=======================================================================
@@ -284,6 +335,7 @@ contains
     if (COMPUTE_ENERGIES) then
      ! increment of plastic energy dissipation
       E_ep = s(:,:,1)*dep(:,:,1) + s(:,:,2)*dep(:,:,2) + 2d0*s(:,:,3)*dep(:,:,3)
+  
      ! total elastic energy change
       i1_0 = m%e0(1) + m%e0(2)
       i2_0 = m%e0(1)*m%e0(1) +m%e0(2)*m%e0(2) +2d0*m%e0(3)*m%e0(3)


### PR DESCRIPTION
W term implemented in plastic material.

Tested manually:
New plastic material with no W in the input file produces the same result as the old plastic simulation.
![image](https://github.com/user-attachments/assets/db198d3b-0eb7-40bf-9147-f80d51b5876a)

Finite W produces 2.5D results:
![image](https://github.com/user-attachments/assets/14a4ee61-365d-49ee-80f5-4de52bcd7d7d)

Stress angle psi = 45
Overstress S = 0.56
Closeness to plastic failure = 0.63

Input file (no W):
```
#----- Some general parameters ----------------
&GENERAL iexec=1, ngll=5, fmax=3.d0 , ndof=2 ,
  title = '2D plastic in-plane model', verbose='1111' , ItInfo = 400/ 

#----- Build the mesh ---------------------------
&MESH_DEF  method = 'CARTESIAN'/
&MESH_CART ezflt=-1, xlim=0d3,100d3, zlim=-50d3,50d3, nelem=160,160/

#---- Material parameters --------------
&MATERIAL tag=1, kind='PLAST'  /
&MAT_PLASTIC cp=5770.d0, cs=3330.d0, rho=2705.d0, phi = 30.d0, coh = 9.669501d6, Tv = 0.0561d0,
                 e0 = -4.162378e-04, -4.162378e-04, 3.504802e-04 /

#----- Boundary conditions ---------------------
&BC_DEF  tags = 5,6 , kind = 'DYNFLT' /
&BC_DYNFLT friction='SWF','TWF', Tn=-50d6, Tt=2.102564d7 /
&BC_DYNFLT_SWF Dc=2d0, MuS=0.6d0, MuD=0.1d0 /
&BC_DYNFLT_TWF kind=1, MuS=0.6d0, MuD=0.1d0, Mu0=0.6d0,
               X=0.d0, Z=0.d0, V=0.333d3, L=0.1665d3, T=60d0 /

&BC_DEF  tag = 1 , kind = 'ABSORB' /
&BC_DEF  tag = 2 , kind = 'ABSORB' /
&BC_DEF  tag = 3 , kind = 'ABSORB' /
&BC_DEF  tag = 4 , kind = 'DIRNEU' /
&BC_DIRNEU h='N', v='D' /

#---- Time scheme settings ----------------------
&TIME  kind='leapfrog', TotalTime=80 /

#----- Receivers ---------------------------------
#&REC_LINE number = 10 , first = 0d3,10d3, last = 50.d3,10d3, isamp=20, AtNode=F /

#--------- Plots settings ----------------------
&SNAP_DEF itd=1000, fields ='DVSE',bin=T,ps=F /
&SNAP_PS  vectors=F, interpol=T, DisplayPts=6, ScaleField=0d0   /
```

Input file (W = 10 km):
```
#----- Some general parameters ----------------
&GENERAL iexec=1, ngll=5, fmax=3.d0 , W=10d3, ndof=2 ,
  title = '2.5D plastic in-plane model', verbose='1111' , ItInfo = 400/ 

#----- Build the mesh ---------------------------
&MESH_DEF  method = 'CARTESIAN'/
&MESH_CART ezflt=-1, xlim=0d3,100d3, zlim=-50d3,50d3, nelem=160,160/

#---- Material parameters --------------
&MATERIAL tag=1, kind='PLAST'  /
&MAT_PLASTIC cp=5770.d0, cs=3330.d0, rho=2705.d0, phi = 30.d0, coh = 9.669501d6, Tv = 0.0561d0,
                 e0 = -4.162378e-04, -4.162378e-04, 3.504802e-04 /

#----- Boundary conditions ---------------------
&BC_DEF  tags = 5,6 , kind = 'DYNFLT' /
&BC_DYNFLT friction='SWF','TWF', Tn=-50d6, Tt=2.102564d7 /
&BC_DYNFLT_SWF Dc=2d0, MuS=0.6d0, MuD=0.1d0 /
&BC_DYNFLT_TWF kind=1, MuS=0.6d0, MuD=0.1d0, Mu0=0.6d0,
               X=0.d0, Z=0.d0, V=0.333d3, L=0.1665d3, T=60d0 /

&BC_DEF  tag = 1 , kind = 'ABSORB' /
&BC_DEF  tag = 2 , kind = 'ABSORB' /
&BC_DEF  tag = 3 , kind = 'ABSORB' /
&BC_DEF  tag = 4 , kind = 'DIRNEU' /
&BC_DIRNEU h='N', v='D' /

#---- Time scheme settings ----------------------
&TIME  kind='leapfrog', TotalTime=80 /

#----- Receivers ---------------------------------
#&REC_LINE number = 10 , first = 0d3,10d3, last = 50.d3,10d3, isamp=20, AtNode=F /

#--------- Plots settings ----------------------
&SNAP_DEF itd=1000, fields ='DVSE',bin=T,ps=F /
&SNAP_PS  vectors=F, interpol=T, DisplayPts=6, ScaleField=0d0   /
```

