### PR TITLE
Add W energy term (contribution to elastic energy)

### DIFF
--- a/SRC/energy.f90
+++ b/SRC/energy.f90
@@ -7,6 +7,7 @@ module energy
     double precision :: E_ep = 0d0 ! cumulative plastic energy
     double precision :: E_k = 0d0  ! kinetic energy
     double precision :: E_el = 0d0  ! elastic energy
+    double precision :: E_W = 0d0  ! additional elastic energy term for 2.5D
     double precision :: sg(3) = 0d0  ! damage stress glut
     double precision :: sgp(3) = 0d0  ! plastic stress glut 
     integer :: iout_E = 0          ! output unit for energies
@@ -43,10 +44,14 @@ contains
   end subroutine stress_glut_init
 
 !=======================================================================
+  ! Compute kinetic energy and additional elastic energy term for 2.5D
+  !
   subroutine energy_compute(energy,matpro,matwrk,grid,fields)
 
   use prop_mat    , only : matpro_elem_type
   use mat_gen     , only : matwrk_elem_type
+  use mat_plastic , only : MAT_PLAST_get_beta
+  use mat_elastic , only : MAT_ELAST_get_beta
   use spec_grid   , only : sem_grid_type, SE_VolumeWeights
   use fields_class, only : fields_type,FIELD_get_elem
   use prop_mat, only : MAT_getProp
@@ -57,32 +62,47 @@ contains
   type(sem_grid_type), intent(in) :: grid
   type(fields_type), intent(in) :: fields
 
-  double precision :: v(grid%ngll,grid%ngll,fields%ndof)
-  double precision, dimension(grid%ngll,grid%ngll) :: rho, v2, w
+  double precision, dimension(grid%ngll,grid%ngll,fields%ndof) :: d, v
+  double precision, dimension(grid%ngll,grid%ngll) :: rho, v2, d2, w, beta
   integer :: e
 
   energy%E_k = 0d0
+  energy%E_W = 0d0
 
   do e=1,grid%nelem
 
     v = FIELD_get_elem(fields%veloc,grid%ibool(:,:,e))
+    d = FIELD_get_elem(fields%displ,grid%ibool(:,:,e))
     if (fields%ndof==1) then
       v2 = v(:,:,1)*v(:,:,1)
+      d2 = d(:,:,1)*d(:,:,1)
     else
       v2 = v(:,:,1)*v(:,:,1) + v(:,:,2)*v(:,:,2)
+      d2 = d(:,:,1)*d(:,:,1) + d(:,:,2)*d(:,:,2)
     endif
     call MAT_getProp(rho,matpro(e),'rho')
+    
+    if (associated(matwrk(e)%plast)) then
+      call MAT_PLAST_get_beta(matwrk(e)%plast, beta)
+    elseif (associated(matwrk(e)%elast)) then
+      call MAT_ELAST_get_beta(matwrk(e)%elast, beta)
+    else
+      beta = 0d0
+    endif
+
     if (associated(matwrk(e)%derint)) then
       w = matwrk(e)%derint%weights
     else
       w = SE_VolumeWeights(grid,e)
     endif
-    energy%E_k = energy%E_k + sum(w*rho*v2) 
+    energy%E_k = energy%E_k + sum(w*rho*v2)
+    energy%E_W = energy%E_W + sum(beta*d2)
 
   enddo
 
   energy%E_k = 0.5d0*energy%E_k
-  
+  energy%E_W = 0.5d0*energy%E_W
+
   end subroutine energy_compute
 
 !=======================================================================
@@ -91,7 +111,7 @@ contains
   type(energy_type), intent(in) :: energy
   double precision, intent(in) :: time
 
-  write(energy%iout_E,'(4D24.16)') time, energy%E_ep, energy%E_k, energy%E_el
+  write(energy%iout_E,'(5D24.16)') time, energy%E_ep, energy%E_k, energy%E_el, energy%E_W
   
   end subroutine energy_write
 

--- a/SRC/mat_elastic.f90
+++ b/SRC/mat_elastic.f90
@@ -29,7 +29,7 @@ module mat_elastic
           , MAT_ELAST_init_elem_prop, MAT_ELAST_init_elem_work &
           , MAT_ELAST_f, MAT_ELAST_stress &
           , MAT_ELAST_memwrk, MAT_ELAST_mempro &
-          , MAT_ELAST_add_25D_f
+          , MAT_ELAST_add_25D_f, MAT_ELAST_get_beta
 
 
 contains
@@ -422,6 +422,22 @@ end subroutine MAT_ELAST_init_25D
   endif
 
   end subroutine MAT_ELAST_f
+  
+!=======================================================================
+! Get beta subroutine
+!
+subroutine MAT_ELAST_get_beta(m, beta_out)
+  type(matwrk_elast_type), intent(in) :: m
+  double precision, intent(out) :: beta_out(:,:)
+
+  beta_out = 0d0
+
+  if (.not. associated(m%beta)) then
+    return  ! Do nothing and leave beta_out as 0
+  endif
+
+  beta_out = m%beta
+end subroutine MAT_ELAST_get_beta
 
 !=======================================================================
 ! Compute the forces acted on "crustal plane" approximated by Lapusta and Rice

--- a/SRC/mat_plastic.f90
+++ b/SRC/mat_plastic.f90
@@ -28,7 +28,7 @@ module mat_plastic
           , MAT_isPlastic, MAT_anyPlastic, MAT_PLAST_read, MAT_PLAST_init_elem_prop &
           , MAT_PLAST_init_elem_work, MAT_PLAST_stress, MAT_PLAST_export &
           , MAT_PLAST_mempro, MAT_PLAST_memwrk &
-          , MAT_PLAST_add_25D_f
+          , MAT_PLAST_add_25D_f, MAT_PLAST_get_beta
   
 contains
 
@@ -239,6 +239,22 @@ contains
   endif
 
 end subroutine MAT_PLAST_init_25D
+
+!=======================================================================
+! Get beta subroutine
+!
+subroutine MAT_PLAST_get_beta(m, beta_out)
+  type(matwrk_plast_type), intent(in) :: m
+  double precision, intent(out) :: beta_out(:,:)
+
+  beta_out = 0d0
+
+  if (.not. associated(m%beta)) then
+    return  ! Do nothing and leave beta_out as 0
+  endif
+
+  beta_out = m%beta
+end subroutine MAT_PLAST_get_beta
 
 !=======================================================================
 ! Compute the forces acted on "crustal plane" approximated by Lapusta and Rice


### PR DESCRIPTION
Added a separate column of energy output: elastic energy contribution for 2.5D models.
Term F in eq 70 of Weng and Ampuero 2019

If there's no W in the input file, a column of 0s is written.

Tested with 2.5D models: now Sum = Epl + Gc + Heat + Ek = Eel (computed)
Light blue (Sum) and orange (dEel) lines should overlap in the plot below:
The mismatch later in the simulation is related to reflections off the boundaries.
![image](https://github.com/user-attachments/assets/6f5f6794-08ba-4c69-a2a1-4d8732c14c6e)

Damage:
![image](https://github.com/user-attachments/assets/764f738b-48f0-4aba-8993-85109b8261ca)

Input file (psi_45_S_0.56_CF_0.63_W_10):
```
#----- Some general parameters ----------------
&GENERAL iexec=1, ngll=5, fmax=3.d0 , W=10d3, ndof=2 ,
  title = '2.5D plastic in-plane model', verbose='1111' , ItInfo = 400/ 

#----- Build the mesh ---------------------------
&MESH_DEF  method = 'CARTESIAN'/
&MESH_CART ezflt=-1, xlim=0d3,100d3, zlim=-50d3,50d3, nelem=160,160/

#---- Material parameters --------------
&MATERIAL tag=1, kind='PLAST'  /
&MAT_PLASTIC cp=5770.d0, cs=3330.d0, rho=2705.d0, phi = 30.d0, coh = 9.669501d6, Tv = 0.0561d0,
                 e0 = -4.162378e-04, -4.162378e-04, 3.504802e-04 /

#----- Boundary conditions ---------------------
&BC_DEF  tags = 5,6 , kind = 'DYNFLT' /
&BC_DYNFLT friction='SWF','TWF', Tn=-50d6, Tt=2.102564d7 /
&BC_DYNFLT_SWF Dc=2d0, MuS=0.6d0, MuD=0.1d0 /
&BC_DYNFLT_TWF kind=1, MuS=0.6d0, MuD=0.1d0, Mu0=0.6d0,
               X=0.d0, Z=0.d0, V=0.333d3, L=0.1665d3, T=60d0 /

&BC_DEF  tag = 1 , kind = 'ABSORB' /
&BC_DEF  tag = 2 , kind = 'ABSORB' /
&BC_DEF  tag = 3 , kind = 'ABSORB' /
&BC_DEF  tag = 4 , kind = 'DIRNEU' /
&BC_DIRNEU h='N', v='D' /

#---- Time scheme settings ----------------------
&TIME  kind='leapfrog', TotalTime=80 /

#----- Receivers ---------------------------------
#&REC_LINE number = 10 , first = 0d3,10d3, last = 50.d3,10d3, isamp=20, AtNode=F /

#--------- Plots settings ----------------------
&SNAP_DEF itd=1000, fields ='DVSE',bin=T,ps=F /
&SNAP_PS  vectors=F, interpol=T, DisplayPts=6, ScaleField=0d0   /

```

