### PR TITLE
Jpampuero patch 1

### DIFF
--- a/SRC/fields.f90
+++ b/SRC/fields.f90
@@ -19,7 +19,7 @@ module fields_class
   end interface FIELD_add_elem
 
   public :: fields_type, FIELDS_read, FIELDS_init &
-          , FIELD_get_elem, FIELD_add_elem, FIELD_strain_elem, FIELD_divcurl_elem
+          , FIELD_get_elem, FIELD_get_elem_sub, FIELD_add_elem, FIELD_strain_elem, FIELD_divcurl_elem
 
 contains
 
@@ -168,6 +168,25 @@ function FIELD_get_elem_2(Fin,ibool) result(fout)
   enddo
 
 end function FIELD_get_elem_2
+
+!-----------------------------------------------------------------------------
+subroutine FIELD_get_elem_sub(Fin,ibool,fout)
+
+  double precision, intent(in) :: Fin(:,:)
+  integer, intent(in) :: ibool(:,:)
+  double precision, intent(out) :: fout(size(ibool,1),size(ibool,2),size(Fin,2))
+
+  integer :: i,j,k,ngll
+
+  ngll = size(ibool,1)
+  do j=1,ngll
+  do i=1,ngll
+    k = ibool(i,j)
+    fout(i,j,:) = Fin(k,:)
+  enddo
+  enddo
+
+end subroutine FIELD_get_elem_sub
 
 !=============================================================================
 function FIELD_strain_elem(Uloc,ngll,ndof,grid,e) result(eij)

--- a/SRC/solver.f90
+++ b/SRC/solver.f90
@@ -272,7 +272,7 @@ end subroutine solve_quasi_static
 !
 subroutine compute_Fint(f,d,v,pb)
 
-  use fields_class, only : FIELD_get_elem, FIELD_add_elem
+  use fields_class, only : FIELD_get_elem_sub, FIELD_add_elem   ! FIELD_get_elem,
   use mat_gen, only : MAT_Fint
 
   double precision, dimension(:,:), intent(out) :: f
@@ -289,8 +289,9 @@ subroutine compute_Fint(f,d,v,pb)
   pb%energy%sgp  = 0d0
 
   do e = 1,pb%grid%nelem
-    dloc = FIELD_get_elem(d,pb%grid%ibool(:,:,e))
-    vloc = FIELD_get_elem(v,pb%grid%ibool(:,:,e))
+    
+    call FIELD_get_elem(d,pb%grid%ibool(:,:,e),dloc)     !dloc = FIELD_get_elem(d,pb%grid%ibool(:,:,e))
+    call FIELD_get_elem(v,pb%grid%ibool(:,:,e),vloc)     !vloc = FIELD_get_elem(v,pb%grid%ibool(:,:,e))
     call MAT_Fint(floc,dloc,vloc,pb%matpro(e),pb%matwrk(e), & 
                    pb%grid%ngll,pb%fields%ndof,pb%time%dt,pb%grid, &
                    E_ep,E_el,sg,sgp)

--- a/SRC/solver.f90
+++ b/SRC/solver.f90
@@ -290,8 +290,8 @@ subroutine compute_Fint(f,d,v,pb)
 
   do e = 1,pb%grid%nelem
     
-    call FIELD_get_elem(d,pb%grid%ibool(:,:,e),dloc)
-    call FIELD_get_elem(v,pb%grid%ibool(:,:,e),vloc)
+    call FIELD_get_elem_sub(d,pb%grid%ibool(:,:,e),dloc)
+    call FIELD_get_elem_sub(v,pb%grid%ibool(:,:,e),vloc)
     call MAT_Fint(floc,dloc,vloc,pb%matpro(e),pb%matwrk(e), & 
                    pb%grid%ngll,pb%fields%ndof,pb%time%dt,pb%grid, &
                    E_ep,E_el,sg,sgp)

--- a/SRC/solver.f90
+++ b/SRC/solver.f90
@@ -272,7 +272,7 @@ end subroutine solve_quasi_static
 !
 subroutine compute_Fint(f,d,v,pb)
 
-  use fields_class, only : FIELD_get_elem_sub, FIELD_add_elem   ! FIELD_get_elem,
+  use fields_class, only : FIELD_get_elem_sub, FIELD_add_elem
   use mat_gen, only : MAT_Fint
 
   double precision, dimension(:,:), intent(out) :: f
@@ -290,8 +290,8 @@ subroutine compute_Fint(f,d,v,pb)
 
   do e = 1,pb%grid%nelem
     
-    call FIELD_get_elem(d,pb%grid%ibool(:,:,e),dloc)     !dloc = FIELD_get_elem(d,pb%grid%ibool(:,:,e))
-    call FIELD_get_elem(v,pb%grid%ibool(:,:,e),vloc)     !vloc = FIELD_get_elem(v,pb%grid%ibool(:,:,e))
+    call FIELD_get_elem(d,pb%grid%ibool(:,:,e),dloc)
+    call FIELD_get_elem(v,pb%grid%ibool(:,:,e),vloc)
     call MAT_Fint(floc,dloc,vloc,pb%matpro(e),pb%matwrk(e), & 
                    pb%grid%ngll,pb%fields%ndof,pb%time%dt,pb%grid, &
                    E_ep,E_el,sg,sgp)


### PR DESCRIPTION
Optimizations in compute elastic forces for P-SV: change functions to subroutines (avoid temporary array creation and copy) and inlined matrix-matrix multiplications.